### PR TITLE
Update Expertise section content and icons

### DIFF
--- a/src/components/Expertise.tsx
+++ b/src/components/Expertise.tsx
@@ -1,44 +1,37 @@
 import React from "react";
-import '@fortawesome/free-regular-svg-icons'
+import '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faReact, faDocker, faPython } from '@fortawesome/free-brands-svg-icons';
+import { faAws, faGitlab } from '@fortawesome/free-brands-svg-icons';
+import { faChartLine } from '@fortawesome/free-solid-svg-icons';
 import Chip from '@mui/material/Chip';
 import '../assets/styles/Expertise.scss';
 
 const labelsFirst = [
-    "React",
-    "TypeScript",
-    "JavaScript",
-    "HTML5",
-    "CSS3",
-    "SASS",
-    "Flask",
-    "Python",
-    "SQL",
-    "PostgreSQL",
-    "Postman"
+    "Terraform",
+    "CloudFormation",
+    "Ansible",
+    "AWS",
+    "GCP",
+    "Kubernetes",
+    "Docker"
 ];
 
 const labelsSecond = [
-    "Git",
+    "GitLab CI/CD",
     "GitHub Actions",
-    "Docker",
-    "AWS",
-    "Azure",
-    "Linux",
-    "Snowflake",
-    "Pandas",
-    "Selenium",
+    "Git-flow",
+    "Bash",
+    "Python",
+    "Nexus"
 ];
 
 const labelsThird = [
-    "OpenAI",
-    "Groq",
-    "LangChain",
-    "Qdrant",
-    "Hugging Face",
-    "LlamaIndex",
-    "Streamlit",
+    "Prometheus",
+    "Grafana",
+    "Zabbix",
+    "CloudWatch",
+    "ELK Stack",
+    "Datadog"
 ];
 
 function Expertise() {
@@ -48,9 +41,9 @@ function Expertise() {
             <h1>Expertise</h1>
             <div className="skills-grid">
                 <div className="skill">
-                    <FontAwesomeIcon icon={faReact} size="3x"/>
-                    <h3>Full Stack Web Development</h3>
-                    <p>I have built a diverse array of web applications from scratch using modern technologies such as React and Flask. I have a strong proficiency in the SDLC process and frontend + backend development.</p>
+                    <FontAwesomeIcon icon={faAws} size="3x"/>
+                    <h3>Cloud Infrastructure & Automation</h3>
+                    <p>Designed and automated cloud environments on AWS and GCP using Terraform and CloudFormation, orchestrating Kubernetes workloads with Docker.</p>
                     <div className="flex-chips">
                         <span className="chip-title">Tech stack:</span>
                         {labelsFirst.map((label, index) => (
@@ -60,9 +53,9 @@ function Expertise() {
                 </div>
 
                 <div className="skill">
-                    <FontAwesomeIcon icon={faDocker} size="3x"/>
-                    <h3>DevOps & Automation</h3>
-                    <p>Once the application is built, I help clients set up DevOps testing, CI/CD pipelines, and deployment automation to support the successful Go-Live.</p>
+                    <FontAwesomeIcon icon={faGitlab} size="3x"/>
+                    <h3>CI/CD & DevOps</h3>
+                    <p>Implemented robust GitLab CI/CD pipelines and GitHub Actions workflows, automating build and deployment processes with Bash and Python scripts.</p>
                     <div className="flex-chips">
                         <span className="chip-title">Tech stack:</span>
                         {labelsSecond.map((label, index) => (
@@ -72,9 +65,9 @@ function Expertise() {
                 </div>
 
                 <div className="skill">
-                    <FontAwesomeIcon icon={faPython} size="3x"/>
-                    <h3>GenAI & LLM</h3>
-                    <p>Stay relevant in the market by leveraging the latest AI models in your projects. I have professional experience building enterprise grade GenAI-enabled solutions to empower intelligent decision making.</p>
+                    <FontAwesomeIcon icon={faChartLine} size="3x"/>
+                    <h3>Monitoring & Reliability</h3>
+                    <p>Established monitoring solutions with Prometheus, Grafana, Zabbix and CloudWatch to ensure system reliability and proactive alerting.</p>
                     <div className="flex-chips">
                         <span className="chip-title">Tech stack:</span>
                         {labelsThird.map((label, index) => (


### PR DESCRIPTION
## Summary
- clean up stray semicolon and imports
- group expertise labels by technology area
- rewrite expertise skill sections with new headings and icons

## Testing
- `npm install`
- `CI=true npm test --silent` *(fails: IntersectionObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6844f1855b54832db80d79b5d04d8825